### PR TITLE
Fix yad warning

### DIFF
--- a/snap/local/src/pre-install
+++ b/snap/local/src/pre-install
@@ -30,7 +30,7 @@ function install() {
     # Downloads a file with progress using wget and yad
     wget "${INSTALL_URL}" -O "${TMPDIR}/${INSTALL_EXE}" 2>&1 | \
     perl -p -e '$| = 1; s/^.* +([0-9]+%) +([0-9,.]+[GMKB]) +([0-9hms,.]+).*$/\1\n# Downloading... \2 (\3)/' | \
-    yad --progress --title="${INSTALL_EXE}" --width=400 --center --no-buttons --auto-close --auto-kill --on-top --no-escape
+    yad --progress --title="${INSTALL_EXE}" --width=400 --center --no-buttons --auto-close --auto-kill --on-top --no-escape 2>/dev/null
     # Unpack setup files
     7z -y x "${TMPDIR}/${INSTALL_EXE}" -o"${TMPDIR}/dl"
     # Installs the application
@@ -104,7 +104,7 @@ function install_us() {
       --button="Install:0" --button="Exit:1" \
       --text "Select your language for installer download:" \
       --entry-text \
-      "English" "French" "German" "Japanese" "Spanish")
+      "English" "French" "German" "Japanese" "Spanish" 2>/dev/null)
   ret=$?
 
   [[ $ret -eq 1 ]] && exit 0


### PR DESCRIPTION
Fix two yad calls in pre-install without stderr suppression. Sommelier's own yad calls (wineboot progress, winetricks progress) already suppress stderr via 2&>/dev/null.