### PR TITLE
fix: adapt install hooks to core24 win64 prefix

### DIFF
--- a/snap/local/src/pre-install
+++ b/snap/local/src/pre-install
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 # acrordrdc env
-progHome="$WINEPREFIX/drive_c/Program Files/Adobe/Acrobat Reader DC/Reader"
+progHome="$WINEPREFIX/drive_c/Program Files (x86)/Adobe/Acrobat Reader DC/Reader"
 progBin="AcroRd32.exe"
-progSetup="$WINEPREFIX/drive_c/Program Files/Adobe/Acrobat Reader DC/Setup Files/{AC76BA86-7AD7-1033-7B44-AC0F074E4100}"
+progSetup="$WINEPREFIX/drive_c/Program Files (x86)/Adobe/Acrobat Reader DC/Setup Files/{AC76BA86-7AD7-1033-7B44-AC0F074E4100}"
 prefixFont="$WINEPREFIX/drive_c/windows/Fonts"
 
-$WINETRICKS --unattended riched20 vcrun2015
+winetricks --unattended riched20 vcrun2015
 
 # Get mspatcha.dll from snap bundle
-cp "$SNAP/sommelier/hooks/mspatcha.dll" "$WINEPREFIX/drive_c/windows/system32/mspatcha.dll"
+cp "$SNAP/sommelier/hooks/mspatcha.dll" "$WINEPREFIX/drive_c/windows/syswow64/mspatcha.dll"
 
 INSTALL_URL_DE="https://ardownload2.adobe.com/pub/adobe/reader/win/AcrobatDC/2001320074/AcroRdrDC2001320074_de_DE.exe"
 INSTALL_URL_US="https://ardownload2.adobe.com/pub/adobe/reader/win/AcrobatDC/2001320074/AcroRdrDC2001320074_en_US.exe"
@@ -41,9 +41,9 @@ function install() {
     # Apply reg
     wget --no-check-certificate -q https://gist.github.com/mmtrt/896cf131e3956b23e8e47a5a52f58b01/raw/097cbd0eeb836d69a84423aaef9a7ead2840a111/acrordr -P ${TMPDIR} && wine regedit ${TMPDIR}/acrordr && rm ${TMPDIR}/acrordr
     # set prefix os to xp
-    $WINETRICKS --unattended winxp
+    winetricks --unattended winxp
     # Rename some files which are going rouge on closing acrordr
-    cd "$WINEPREFIX/drive_c/Program Files/Common Files/Adobe/ARM/1.0"
+    cd "$WINEPREFIX/drive_c/Program Files (x86)/Common Files/Adobe/ARM/1.0"
     mv armsvc.exe armsvc.exe_disabled
     mv AdobeARM.exe AdobeARM.exe_disabled
     mv AdobeARMHelper.exe AdobeARMHelper.exe_disabled

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,7 +37,7 @@ environment:
   NO_AT_BRIDGE: "1"
   DISABLE_WAYLAND: "1" # Fix gtk decoration under wayland session
   SYSTEM_WGETRC: $SNAP/wine-runtime/etc/wgetrc
-  RUN_EXE: "C:/Program Files/Adobe/Acrobat Reader DC/Reader/AcroRd32.exe"
+  RUN_EXE: "C:/Program Files (x86)/Adobe/Acrobat Reader DC/Reader/AcroRd32.exe"
 
 apps:
   acrordrdc:


### PR DESCRIPTION
The core24 migration switched to a WoW64-only Wine build, which creates a win64 prefix instead of win32. This broke the install hooks in three ways:
- $WINETRICKS is no longer exported by the core24 sommelier, so the hooks collapsed to "--unattended: command not found".
- 32-bit Adobe Reader now installs under "Program Files (x86)", so progHome, progSetup, the ARM dir and RUN_EXE all needed the (x86) path.
- The 32-bit installer loads mspatcha from syswow64 (system32 is 64-bit on a win64 prefix).